### PR TITLE
Fix < character, common in React errors

### DIFF
--- a/lib/capybara/chromedriver/logger/message.rb
+++ b/lib/capybara/chromedriver/logger/message.rb
@@ -45,6 +45,7 @@ module Capybara
         def formatted_message
           message
             .gsub('\n', "\n")
+            .gsub('\u003C', "\u003C")
             .split("\n")
             .map { |line| "#{LEADING_SPACES}#{line}" }
             .join("\n")


### PR DESCRIPTION
Otherwise they look like this:
```
 severe  http://127.0.0.1:62364/packs-test/vendor-60d2273d55997e20e78d.js 28748:12
     The above error occurred in the \u003CModeHeader> component:
```