### PR TITLE
Prevent errors from being raised if they match a filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.0
+
+* Prevent errors from being raised if they match a filter
+
 # 0.2.1 [June 23, 2018]
 
 * Added `filter_levels` option for filtering by log level (closes #4)

--- a/lib/capybara/chromedriver/logger/collector.rb
+++ b/lib/capybara/chromedriver/logger/collector.rb
@@ -32,9 +32,12 @@ module Capybara
         def flush_logs!
           browser_logs.each do |log|
             message = Message.new(log)
-            errors << message if message.error?
+            
+            next if should_filter?(message)
 
-            log_destination.puts message.to_s unless should_filter?(message)
+            errors << message if message.error?
+            
+            log_destination.puts message.to_s
           end
         end
 

--- a/lib/capybara/chromedriver/logger/version.rb
+++ b/lib/capybara/chromedriver/logger/version.rb
@@ -1,7 +1,7 @@
 module Capybara
   module Chromedriver
     module Logger
-      VERSION = "0.2.1"
+      VERSION = "0.3.0"
     end
   end
 end

--- a/spec/capybara/chromedriver/logger/collector_spec.rb
+++ b/spec/capybara/chromedriver/logger/collector_spec.rb
@@ -67,6 +67,16 @@ RSpec.describe "collector", with_server: true, js: true, type: :feature do
     Capybara::Chromedriver::Logger.filter_levels = nil
   end
 
+  it "should ignore filtered messages" do
+    Capybara::Chromedriver::Logger.raise_js_errors = true
+    Capybara::Chromedriver::Logger.filters = [/A console error/i]
+    visit "/severe"
+
+    expect_to_have_inserted_element
+    logger.flush_and_check_errors!
+    expect_no_log_messages
+  end
+
   def expect_no_log_messages
     expect(log_destination.string).to eq('')
   end


### PR DESCRIPTION
Errors were still raised even if a message matched one of the defined `filters`. This ignores them completely to match the behavior described by the documentation:

```
# If you filter out any errors with the `filters` option, they will
# not trigger an exception in your spec examples.
```

Fixes #6. 

I'm not totally sure how you prefer to deal with versioning. I bumped the version to `0.3.0` here, so let me know if you want me to handle that differently. It seemed to be warrant a minor bump since it does change the behavior significantly, even if that behavior was contrary to the documentation.