### PR TITLE
Filter Errors Before Raising Exception

### DIFF
--- a/lib/capybara/chromedriver/logger/collector.rb
+++ b/lib/capybara/chromedriver/logger/collector.rb
@@ -32,9 +32,12 @@ module Capybara
         def flush_logs!
           browser_logs.each do |log|
             message = Message.new(log)
-            errors << message if message.error?
 
-            log_destination.puts message.to_s unless should_filter?(message)
+            unless should_filter?(message)
+              errors << message if message.error?
+
+              log_destination.puts message.to_s
+            end
           end
         end
 

--- a/spec/capybara/chromedriver/logger/collector_spec.rb
+++ b/spec/capybara/chromedriver/logger/collector_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe "collector", with_server: true, js: true, type: :feature do
 
   before do
     Capybara::Chromedriver::Logger.raise_js_errors = false
+    Capybara::Chromedriver::Logger.filters = []
   end
 
   it "receiving no errors" do
@@ -36,6 +37,17 @@ RSpec.describe "collector", with_server: true, js: true, type: :feature do
     expect { logger.flush_and_check_errors! }
       .to raise_error(Capybara::Chromedriver::Logger::JsError, /A console error/)
     expect_log_message("A console error")
+  end
+
+  it "receiving console errors with error raising and message text filtered" do
+    Capybara::Chromedriver::Logger.filters = [/A console error/]
+    Capybara::Chromedriver::Logger.raise_js_errors = true
+
+    visit "/severe"
+
+    expect_to_have_inserted_element
+    expect { logger.flush_and_check_errors! }.to_not raise_error
+    expect(log_destination.string).to be_empty
   end
 
   it "receiving logs with linebreaks" do

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -22,7 +22,8 @@ Capybara.register_driver :selenium do |app|
 
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
     chromeOptions: {
-      args: args
+      args: args,
+      w3c: false
     },
     loggingPrefs: {
       browser: 'ALL'


### PR DESCRIPTION
When `Capybara::Chromedriver::Logger.raise_js_errors` is turned on,
errors will be output and thrown in the tests even if the text for these
errors are filtered by one of the regular expressions in the
`Capybara::Chromedriver::Logger.filters` collection. Ensure that the
error does not match one of these filters before proceeding to log it as
an error (and throw an exception in test teardown).