### PR TITLE
CI: Cache Bundler, drop unused sudo: false directive, use existing Bundler version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ addons:
   chrome: stable
 rvm:
   - 2.6.5
-
+cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
-sudo: false
 language: ruby
 addons:
   chrome: stable
 rvm:
   - 2.6.5
-before_install: gem install bundler -v 1.16.0
+


### PR DESCRIPTION
This PR removes the no-longer-used Travis setting `sudo: false`. See [more at the Travis blog](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).
