### PR TITLE
Enable multi-line log messages

### DIFF
--- a/lib/capybara/chromedriver/logger/message.rb
+++ b/lib/capybara/chromedriver/logger/message.rb
@@ -66,7 +66,7 @@ module Capybara
         end
 
         def extract_file_and_location!
-          match = message.match(/^(.+)\s+?(\d+:\d+)\s+?(.+)$/)
+          match = message.match(/^(.+)\s+?(\d+:\d+)\s+?(.+)$/m)
 
           return unless match
 


### PR DESCRIPTION
Hit the same issue as #25 -- the patch works as described and enabled multi-line console log output. :+1:

Fixes #25

